### PR TITLE
Fixed bullet behavior after hitting an enemy in MP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,8 @@ obj/
 *.ini
 *.log
 *.logs
+Makefile
+CMakeFiles/
+CMakeCache.txt
 CMakeLists.txt.user
 

--- a/src/bullet.cpp
+++ b/src/bullet.cpp
@@ -96,23 +96,22 @@ Bullet::Update()
 
   const auto& game = gameState();
 
-  if (  game.gameMode == GAME_MODE::HUMAN_VS_HUMAN &&
-        planes.at(mFiredBy).isLocal() == true )
-    return;
-
-
   Plane* planeShooter = &planes.at(PLANE_TYPE::BLUE);
   Plane* planeTarget = &planes.at(PLANE_TYPE::RED);
 
   if ( mFiredBy == PLANE_TYPE::RED )
     std::swap(planeShooter, planeTarget);
 
+  const bool shouldProcessDamage = !(game.gameMode == GAME_MODE::HUMAN_VS_HUMAN && 
+                                     planes.at(mFiredBy).isLocal() == true);
 
 //  HIT PLANE
   if ( planeTarget->isHit(mX, mY) == true )
   {
     Destroy();
-    planeTarget->Hit(*planeShooter);
+
+    if ( shouldProcessDamage )
+      planeTarget->Hit(*planeShooter);
 
     return;
   }
@@ -121,9 +120,13 @@ Bullet::Update()
   if ( planeTarget->pilot.ChuteIsHit(mX, mY) == true )
   {
     Destroy();
-    planeTarget->pilot.ChuteHit(*planeShooter);
 
-    eventPush(EVENTS::HIT_CHUTE);
+    if ( shouldProcessDamage )
+    {
+      planeTarget->pilot.ChuteHit(*planeShooter);
+      eventPush(EVENTS::HIT_CHUTE);
+    }
+
     return;
   }
 
@@ -131,9 +134,13 @@ Bullet::Update()
   if ( planeTarget->pilot.isHit(mX, mY) == true )
   {
     Destroy();
-    planeTarget->pilot.Kill(*planeShooter);
 
-    eventPush(EVENTS::HIT_PILOT);
+    if ( shouldProcessDamage )
+    {
+      planeTarget->pilot.Kill(*planeShooter);
+      eventPush(EVENTS::HIT_PILOT);
+    }
+
     return;
   }
 }


### PR DESCRIPTION
In network mode (`HUMAN_VS_HUMAN`), bullets completely bypassed collision processing due to an early return, which resulted in the bullet flying through the enemy after hitting them. This behavior was purely cosmetic. it was not possible to hit an enemy twice with a single bullet.
There were no errors in the game with the bot. I slightly reworked the logic so that the bullet's behavior after hitting the target would be the same.

I also updated `.gitignore` so that there would be less garbage for git after compilation.