### PR TITLE
AI Insane and unlock logic

### DIFF
--- a/include/enums.hpp
+++ b/include/enums.hpp
@@ -128,6 +128,7 @@ namespace DIFFICULTY
     MEDIUM,
     HARD,
     DEVELOPER,
+    INSANE
   };
 }
 

--- a/include/stats.hpp
+++ b/include/stats.hpp
@@ -41,6 +41,8 @@ struct Statistics
 
   uint32_t wins {};
   uint32_t losses {};
+  uint32_t wins_vs_developer {};
+  uint32_t wins_vs_insane {};
 
 
 //  These are calculated

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -35,6 +35,7 @@ void log_message(
 void logSDL2Version();
 bool stats_write();
 bool statsRead();
+bool isInsaneUnlocked();
 
 std::string checkIp( const std::string& );
 bool checkPort( const std::string& );

--- a/src/ai_stuff.cpp
+++ b/src/ai_stuff.cpp
@@ -606,6 +606,16 @@ AiStatePlane::AiStatePlane(
     case DIFFICULTY::DEVELOPER:
       break;
 
+    case DIFFICULTY::INSANE:
+    {
+      throttleWeight = ReactionTimeToWeights(0.05f, 0.05f);
+      pitchWeight = ReactionTimeToWeights(0.05f, 0.05f);
+      shootWeight = ReactionTimeToWeights(0.02f, 0.02f);
+      jumpWeight = ReactionTimeToWeights(0.02f, 0.02f);
+
+      break;
+    }
+
     default:
       assert(false);
   }
@@ -1168,6 +1178,7 @@ AiStatePlane::update(
         }
 
         case DIFFICULTY::DEVELOPER:
+        case DIFFICULTY::INSANE:
         {
           if ( facesBarn == true || facesGround == true )
             actions.push_back(AiAction::Jump);
@@ -1178,7 +1189,8 @@ AiStatePlane::update(
     }
 
 //    Eject during combat
-    else if ( selfHp == 0.f && botDifficulty > DIFFICULTY::EASY )
+    else if ( selfHp == 0.f && botDifficulty > DIFFICULTY::EASY &&
+              botDifficulty != DIFFICULTY::INSANE )
     {
       bool allowJump =
         gameState().features.oneShotKills == false;
@@ -1377,6 +1389,9 @@ AiStatePilot::AiStatePilot(
     }
 
     case DIFFICULTY::DEVELOPER:
+      break;
+
+    case DIFFICULTY::INSANE:
       break;
 
     default:

--- a/src/menu_navigation.cpp
+++ b/src/menu_navigation.cpp
@@ -117,7 +117,7 @@ Menu::Select()
         {
           auto& difficulty = gameState().botDifficulty;
 
-          if ( difficulty < DIFFICULTY::DEVELOPER )
+          if ( difficulty < DIFFICULTY::INSANE )
             difficulty = static_cast <DIFFICULTY> (static_cast <uint8_t> (difficulty) + 1);
           else
             difficulty = DIFFICULTY::EASY;

--- a/src/menu_navigation.cpp
+++ b/src/menu_navigation.cpp
@@ -97,6 +97,11 @@ Menu::Select()
       {
         case MENU_SP::SETUP_GAME:
         {
+          // Block setup if INSANE is selected but not unlocked
+          if ( gameState().botDifficulty == DIFFICULTY::INSANE && !isInsaneUnlocked() &&
+               gameState().gameMode != GAME_MODE::BOT_VS_BOT )
+            break;
+          
           ChangeRoom(ROOMS::MENU_SP_SETUP);
           break;
         }

--- a/src/menu_sp.cpp
+++ b/src/menu_sp.cpp
@@ -76,6 +76,12 @@ Menu::screen_sp()
       aiDifficulty = "Developer";
       break;
     }
+
+    case DIFFICULTY::INSANE:
+    {
+      aiDifficulty = "Insane 0_o";
+      break;
+    }
   }
 
 

--- a/src/menu_sp.cpp
+++ b/src/menu_sp.cpp
@@ -24,6 +24,7 @@
 #include <include/constants.hpp>
 #include <include/game_state.hpp>
 #include <include/textures.hpp>
+#include <include/utility.hpp>
 
 
 void
@@ -92,6 +93,10 @@ Menu::screen_sp()
   draw_text( "AI difficulty: ", 0.040f, 0.2855f + 0.0721f + button::sizeY * 2.f );
   draw_text( aiDifficulty,      0.500f, 0.2855f + 0.0721f + button::sizeY * 2.f );
   draw_text( "Back           ", 0.040f, 0.2855f + 0.0721f + button::sizeY * 3.f );
+
+  if ( gameState().botDifficulty == DIFFICULTY::INSANE && !isInsaneUnlocked() &&
+       gameState().gameMode != GAME_MODE::BOT_VS_BOT)
+    draw_text( "First, beat up Developer!", 0.025f, 0.65f );
 }
 
 void

--- a/src/menu_stats.cpp
+++ b/src/menu_stats.cpp
@@ -222,15 +222,20 @@ Menu::screen_stats_total_page2()
   sprintf( textbuf, "Survivability: %.2f%%", stats.survivability );
   draw_text( textbuf, 0, 0.600f );
 
-
   sprintf( textbuf, "  %d wins", stats.wins );
-  draw_text( textbuf, 0.025f, 0.750f );
+  draw_text( textbuf, 0.025f, 0.700f );
 
   sprintf( textbuf, "  %d losses", stats.losses );
-  draw_text( textbuf, 0.025f, 0.800f );
+  draw_text( textbuf, 0.025f, 0.750f );
 
   sprintf( textbuf, "Win-Lose ratio: %.2f%%", winLose );
-  draw_text( textbuf, 0, 0.850f );
+  draw_text( textbuf, 0, 0.800f );
+
+  sprintf( textbuf, "  %d Developer victories", stats.wins_vs_developer );
+  draw_text( textbuf, 0.025f, 0.850f );
+
+  sprintf( textbuf, "  %d Insane victories", stats.wins_vs_insane );
+  draw_text( textbuf, 0.025f, 0.900f );
 }
 
 

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -915,6 +915,20 @@ Plane::ScoreChange(
   mStats.wins++;
   opponentPlane.mStats.losses++;
 
+  // Track victory against DEVELOPER bot for INSANE unlock
+  if ( game.gameMode == GAME_MODE::HUMAN_VS_BOT &&
+       mIsBot == false &&
+       opponentPlane.isBot() == true &&
+       game.botDifficulty == DIFFICULTY::DEVELOPER )
+    mStats.wins_vs_developer++;
+
+  // Track victories against INSANE bot
+  if ( game.gameMode == GAME_MODE::HUMAN_VS_BOT &&
+       mIsBot == false &&
+       opponentPlane.isBot() == true &&
+       game.botDifficulty == DIFFICULTY::INSANE )
+    mStats.wins_vs_insane++;
+
   game.isRoundFinished = true;
 
   updateRecentStats();

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -529,6 +529,8 @@ stats_write()
   jsonStats["Rescues"]      = picojson::value( (double) stats.rescues );
   jsonStats["Shots"]        = picojson::value( (double) stats.shots );
   jsonStats["Wins"]         = picojson::value( (double) stats.wins );
+  jsonStats["WinsVsDeveloper"] = picojson::value( (double) stats.wins_vs_developer );
+  jsonStats["WinsVsInsane"] = picojson::value( (double) stats.wins_vs_insane );
 
 
   std::string jsonOutput = picojson::value( jsonStats ).serialize( true );
@@ -611,12 +613,25 @@ statsRead()
 
     try { stats.wins = jsonStats.at( "Wins" ).get <double> (); }
     catch ( const std::exception& ) {};
+
+    try { stats.wins_vs_developer = jsonStats.at( "WinsVsDeveloper" ).get <double> (); }
+    catch ( const std::exception& ) {};
+
+    try { stats.wins_vs_insane = jsonStats.at( "WinsVsInsane" ).get <double> (); }
+    catch ( const std::exception& ) {};
   }
   catch ( const std::exception& ) {};
 
   calcDerivedStats(stats);
 
   return true;
+}
+
+bool
+isInsaneUnlocked()
+{
+  const auto& stats = gameState().stats.total;
+  return stats.wins_vs_developer > 0;
 }
 
 


### PR DESCRIPTION
I don't know how you feel about expanding the original game logic, but I will definitely leave this logic in my PS Vita port :D

Since AI Developer is not difficult to defeat by abusing its desire to catapult itself when HP=1, I decided that another difficulty could be added.

This is Insane AI, which:
- Reacts faster than Developer, but is still not perfect;
- Fights to the last, catapults only in case of victory and HP!=3;
- Is harder to defeat than Developer and provides a new experience, as it behaves differently. Although, my best result with it is 6:10 -_-

I also added the logic for unlocking Insane AI - you need to defeat AI Developer at least once. Otherwise, the player will not be able to select Insane.

I also added lines to the statistics with information about victories over AI Developer and Insane.